### PR TITLE
feat(ci): switch crates.io publish to trusted publishing

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -6,7 +6,6 @@ permissions:
   id-token: write
 
 on:
-  pull_request:
   push:
     branches:
       - develop

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
 
       - name: Authenticate with crates.io
-        uses: rust-lang/crates-io-auth-action@3aeff7023ad8cf78f561cbd7ac7fbc6cdb5d16b1 # v1
+        uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.4
 
       - uses: release-plz/action@f708778669256143d984cce4b23592637532e040 # v0.5
         with:

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -42,6 +42,9 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
 
+      - name: Authenticate with crates.io
+        uses: rust-lang/crates-io-auth-action@3aeff7023ad8cf78f561cbd7ac7fbc6cdb5d16b1 # v1
+
       - uses: release-plz/action@f708778669256143d984cce4b23592637532e040 # v0.5
         with:
           command: release

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -3,6 +3,7 @@ name: Release-plz
 permissions:
   pull-requests: write
   contents: write
+  id-token: write
 
 on:
   push:
@@ -29,7 +30,6 @@ jobs:
           command: release-pr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   release-plz-release:
     name: Release
@@ -47,4 +47,3 @@ jobs:
           command: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -6,6 +6,7 @@ permissions:
   id-token: write
 
 on:
+  pull_request:
   push:
     branches:
       - develop

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -6,6 +6,7 @@ permissions:
   id-token: write
 
 on:
+  pull_request:
   push:
     branches:
       - develop
@@ -22,6 +23,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
+          ref: ${{ github.head_ref || github.ref_name }}
 
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
 
@@ -29,7 +31,7 @@ jobs:
         with:
           command: release-pr
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
 
   release-plz-release:
     name: Release
@@ -39,6 +41,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
+          ref: ${{ github.head_ref || github.ref_name }}
 
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-description = "HTTP API error handling utilities for Rust"
+description = "A derive macro for attaching HTTP status codes and user-facing messages to Rust error types."
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.85"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,10 @@
 [workspace.package]
+description = "HTTP API error handling utilities for Rust"
 edition = "2024"
 license = "Apache-2.0"
 rust-version = "1.85"
-repository = "https://github.com/centreon-pulse/rs-api-error"
-homepage = "https://github.com/centreon-pulse/rs-api-error"
+repository = "https://github.com/centreon/rs-api-error"
+homepage = "https://github.com/centreon/rs-api-error"
 keywords = ["derive", "error", "error-handling", "http"]
 readme = "README.md"
 categories = ["rust-patterns"]

--- a/api-error-derive/Cargo.toml
+++ b/api-error-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "api-error-derive"
 version = "0.1.0"
-description = "Procedural macros for the api-error crate"
+description.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/api-error-derive/Cargo.toml
+++ b/api-error-derive/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "api-error-derive"
 version = "0.1.0"
+description = "Procedural macros for the api-error crate"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/api-error/Cargo.toml
+++ b/api-error/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "api-error"
 version = "0.1.0"
-description = "HTTP API error types and utilities for Rust web services"
+description.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/api-error/Cargo.toml
+++ b/api-error/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "api-error"
 version = "0.1.0"
+description = "HTTP API error types and utilities for Rust web services"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -11,7 +12,7 @@ readme.workspace = true
 categories.workspace = true
 
 [dependencies]
-api-error-derive = { path = "../api-error-derive", optional = true }
+api-error-derive = { path = "../api-error-derive", version = "0.1.0", optional = true }
 
 http = "1"
 serde_core = { version = "1", optional = true }


### PR DESCRIPTION
## Summary

- Add `description` field to workspace and crate manifests (required by crates.io)
- Fix repository/homepage URLs (`centreon-pulse` → `centreon`)
- Add `version = "0.1.0"` to `api-error-derive` path dependency (required for crates.io publish)
- Add `id-token: write` permission to enable OIDC trusted publishing
- Remove `CARGO_REGISTRY_TOKEN` from release workflow (no longer needed)

## Why trusted publishing?

Instead of storing a static token in GitHub Secrets (which requires manual rotation), GitHub Actions now authenticates with crates.io via OIDC. A short-lived token is generated per workflow run, scoped to this specific repo and workflow file. No token to rotate, no secret to leak.

## Pre-requisites (already done)

- `api-error` and `api-error-derive` v0.1.0 published to crates.io via `technique-ci` account
- Trusted publisher configured on crates.io for both crates (`centreon/rs-api-error` + `release-plz.yml`)

## Test plan

- [ ] Merge triggers release-plz which attempts a publish via OIDC — check job logs for successful auth
- [ ] Verify no `CARGO_REGISTRY_TOKEN` secret is needed in repo settings

Jira: [MON-196717](https://centreon.atlassian.net/browse/MON-196717)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MON-196717]: https://centreon.atlassian.net/browse/MON-196717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Switched to OIDC publishing by adding id-token, auth action, and removing CARGO_REGISTRY_TOKEN
* Adjusted checkout to use github.head_ref or github.ref_name for branches
* Replaced GITHUB_TOKEN with CENTREON_TECHNIQUE_PAT in release-plz action usage


<sup>[More info](https://app.aikido.dev/featurebranch/scan/106120256?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->