### PR TITLE
chore(ci): filter ci and internal scopes from release-plz version bumps

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,2 +1,3 @@
 [workspace]
 git_release_enable = true
+release_commits = "^(?![^(]*\\((ci|internal)\\))"


### PR DESCRIPTION
## Summary

- Add `release_commits` filter to `release-plz.toml`
- Commits with scopes `(ci)` or `(internal)` no longer trigger a version bump

## Regex

```
^(?![^(]*\((ci|internal)\))
```

| Commit | Résultat |
|---|---|
| `enh(ci): ...` | ❌ no bump |
| `fix(internal): ...` | ❌ no bump |
| `feat(api): ...` | ✅ bump |
| `fix(broker): ...` | ✅ bump |
| `feat: ...` | ✅ bump |

Jira: [MON-196717](https://centreon.atlassian.net/browse/MON-196717)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MON-196717]: https://centreon.atlassian.net/browse/MON-196717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ