### PR TITLE
chore(ci): use [release] tag to control release-plz version bumps

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,3 +1,3 @@
 [workspace]
 git_release_enable = true
-release_commits = "^(?![^(]*\\((ci|internal)\\))"
+release_commits = "\\[release\\]"


### PR DESCRIPTION
  ## Summary

  - Replace regex-based scope exclusion with an opt-in `[release]` tag
  - Only commits containing `[release]` in their message trigger a version bump
  - Previous approach used negative lookahead which is not supported by the Rust regex engine

  ## Usage

  Add `[release]` anywhere in the commit message to trigger a version bump:

  feat(api): add new endpoint [release]
  fix(broker): handle timeout [release]
  enh(ci): update pipeline          ← no bump
  chore(deps): bump serde           ← no bump