### PR TITLE
fix: re-export transitive deps to avoid axum_core not found bug [release]

### DIFF
--- a/api-error-derive/src/expand.rs
+++ b/api-error-derive/src/expand.rs
@@ -36,7 +36,7 @@ pub fn expand(input: DeriveInput) -> TokenStream {
     let api_err_impl = quote! {
         #[automatically_derived]
         impl #impl_generics ApiError for #ident #ty_generics #where_clause {
-            fn status_code(&self) -> ::http::StatusCode {
+            fn status_code(&self) -> ::api_error::__http::StatusCode {
                 #status_code
             }
 
@@ -49,8 +49,8 @@ pub fn expand(input: DeriveInput) -> TokenStream {
     #[cfg(feature = "axum")]
     let axum_impl = Some(quote! {
         #[automatically_derived]
-        impl #impl_generics ::axum_core::response::IntoResponse for #ident #ty_generics #where_clause {
-            fn into_response(self) -> ::axum_core::response::Response {
+        impl #impl_generics ::api_error::axum::__axum_core::response::IntoResponse for #ident #ty_generics #where_clause {
+            fn into_response(self) -> ::api_error::axum::__axum_core::response::Response {
                 ::api_error::axum::ApiErrorResponse::new(&self).into_response()
             }
         }
@@ -80,7 +80,7 @@ fn expand_struct(ident: &Ident, data: DataStruct, attrs: &[Attribute]) -> syn::R
         VariantAttr::InheritMsg { status_code } | VariantAttr::Custom { status_code, .. } => {
             status_code
                 .clone()
-                .unwrap_or(quote! { ::http::StatusCode::INTERNAL_SERVER_ERROR })
+                .unwrap_or(quote! { ::api_error::__http::StatusCode::INTERNAL_SERVER_ERROR })
         }
     };
 
@@ -211,7 +211,7 @@ fn expand_status_arm(
         (_, VariantAttr::Custom { status_code, .. } | VariantAttr::InheritMsg { status_code }) => {
             status_code
                 .clone()
-                .unwrap_or_else(|| quote! { ::http::StatusCode::INTERNAL_SERVER_ERROR })
+                .unwrap_or_else(|| quote! { ::api_error::__http::StatusCode::INTERNAL_SERVER_ERROR })
         }
     };
 

--- a/api-error-derive/src/expand.rs
+++ b/api-error-derive/src/expand.rs
@@ -209,9 +209,9 @@ fn expand_status_arm(
 
         // custom or default status code
         (_, VariantAttr::Custom { status_code, .. } | VariantAttr::InheritMsg { status_code }) => {
-            status_code
-                .clone()
-                .unwrap_or_else(|| quote! { ::api_error::__http::StatusCode::INTERNAL_SERVER_ERROR })
+            status_code.clone().unwrap_or_else(
+                || quote! { ::api_error::__http::StatusCode::INTERNAL_SERVER_ERROR },
+            )
         }
     };
 

--- a/api-error/src/lib.rs
+++ b/api-error/src/lib.rs
@@ -161,6 +161,9 @@ use std::borrow::Cow;
 
 use http::StatusCode;
 
+#[doc(hidden)]
+pub use ::http as __http;
+
 /// Derive macro for implementing [`ApiError`] on enums and structs.
 ///
 /// This macro generates an [`ApiError`] implementation based on
@@ -352,6 +355,9 @@ pub mod axum {
     use serde_core::{Serialize, ser::SerializeMap};
 
     use crate::ApiError;
+
+    #[doc(hidden)]
+    pub use ::axum_core as __axum_core;
 
     pub struct ApiErrorResponse<'a> {
         message: Cow<'a, str>,


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Re-exported http crate as __http to expose transitive dependency
* Changed derive output to reference re-exported __http and axum core paths


<sup>[More info](https://app.aikido.dev/featurebranch/scan/106620506?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->