### PR TITLE
feat: add error responder [release]

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -28,6 +28,8 @@ jobs:
 
       - name: Run tests
         run: cargo test --all-features --workspace
+        env:
+          RUSTDOCFLAGS: --cfg readme_doctest
 
   clippy:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,6 +44,8 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
+ "serde_json",
+ "serde_path_to_error",
  "sync_wrapper",
  "tower",
  "tower-layer",
@@ -253,6 +255,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -164,3 +164,32 @@ let app: Router = Router::new().route("/", get(handler));
 // Status: 404
 // Body: {"message": "Resource not found"}
 ```
+
+### Customizing axum error response format
+
+The default response body is `{"message": "<error msg>"}` with the error's HTTP
+status code. To use a different format, register a custom responder once at
+startup with `api_error::axum::set_error_responder`. Every type deriving
+`ApiError` will route through it.
+
+```rust
+use api_error::ApiError;
+use axum::{Json, response::{IntoResponse, Response}};
+use serde_json::json;
+
+fn my_responder(err: &dyn ApiError) -> Response {
+    let status = err.status_code();
+    let body = json!({
+        "error": {
+            "code": status.as_u16(),
+            "message": err.message(),
+        }
+    });
+    (status, Json(body)).into_response()
+}
+
+fn main() {
+    api_error::axum::set_error_responder(my_responder);
+    // ... build router and serve
+}
+```

--- a/api-error-derive/src/expand.rs
+++ b/api-error-derive/src/expand.rs
@@ -51,7 +51,8 @@ pub fn expand(input: DeriveInput) -> TokenStream {
         #[automatically_derived]
         impl #impl_generics ::api_error::axum::__axum_core::response::IntoResponse for #ident #ty_generics #where_clause {
             fn into_response(self) -> ::api_error::axum::__axum_core::response::Response {
-                ::api_error::axum::ApiErrorResponse::new(&self).into_response()
+                ::api_error::axum::__ERROR_RESPONDER.get().copied()
+                    .unwrap_or(::api_error::axum::default_error_responder)(&self)
             }
         }
     });

--- a/api-error/Cargo.toml
+++ b/api-error/Cargo.toml
@@ -22,7 +22,10 @@ serde_json = { version = "1", optional = true }
 [dev-dependencies]
 thiserror = "2"
 trybuild = "1"
-axum = { version = "0.8", default-features = false }
+axum = { version = "0.8", default-features = false, features = ["json"] }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(readme_doctest)'] }
 
 [features]
 default = ["derive"]

--- a/api-error/src/lib.rs
+++ b/api-error/src/lib.rs
@@ -156,6 +156,38 @@
 //! // Body: {"message": "Resource not found"}
 //! ```
 //!
+//! ### Customizing axum error response format
+//!
+//! The default response body is `{"message": "<error msg>"}` with the error's
+//! HTTP status code. To use a different format, register a custom responder
+//! once at startup with [`axum::set_error_responder`]. Every type deriving
+//! [`ApiError`] will route through it.
+//!
+//! ```no_run
+//! use api_error::ApiError;
+//! use axum_core::response::{IntoResponse, Response};
+//! use http::StatusCode;
+//! use serde_json::json;
+//!
+//! fn my_responder(err: &dyn ApiError) -> Response {
+//!     let status = err.status_code();
+//!     let body = serde_json::to_vec(&json!({
+//!         "error": {
+//!             "code": status.as_u16(),
+//!             "message": err.message(),
+//!         }
+//!     })).unwrap();
+//!     (status, body).into_response()
+//! }
+//!
+//! api_error::axum::set_error_responder(my_responder);
+//! ```
+
+// Compile the README's code blocks as doctests. Opt-in via
+// `RUSTFLAGS="--cfg readme_doctest" cargo test --all-features` (this is what CI runs).
+#[cfg(readme_doctest)]
+#[doc = include_str!("../../README.md")]
+mod _readme_doctest {}
 
 use std::borrow::Cow;
 
@@ -345,7 +377,7 @@ pub trait ApiError: std::error::Error {
 /// Custom implementation for axum integration
 #[cfg(feature = "axum")]
 pub mod axum {
-    use std::borrow::Cow;
+    use std::{borrow::Cow, sync::OnceLock};
 
     use axum_core::{
         body::Body,
@@ -354,10 +386,55 @@ pub mod axum {
     use http::StatusCode;
     use serde_core::{Serialize, ser::SerializeMap};
 
-    use crate::ApiError;
-
     #[doc(hidden)]
     pub use ::axum_core as __axum_core;
+
+    use super::ApiError;
+
+    #[doc(hidden)]
+    pub static __ERROR_RESPONDER: OnceLock<ApiErrorResponder> = OnceLock::new();
+
+    /// A function that converts an [`ApiError`] into an axum [`Response`].
+    ///
+    /// Register one globally with [`set_error_responder`] to customize the
+    /// response format produced by types deriving [`ApiError`].
+    pub type ApiErrorResponder = fn(&dyn ApiError) -> Response;
+
+    /// Sets a custom [`ApiErrorResponder`] that will be used to convert
+    /// [`ApiError`] to a [`Response`].
+    ///
+    /// For a non-panicking alternative, use [`try_set_error_responder`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if the responder is already set.
+    pub fn set_error_responder(f: ApiErrorResponder) {
+        __ERROR_RESPONDER
+            .set(f)
+            .expect("an api error responder should be set only once");
+    }
+
+    /// Tries to set a custom [`ApiErrorResponder`] that will be used to convert
+    /// [`ApiError`] to a [`Response`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the responder is already set.
+    pub fn try_set_error_responder(f: ApiErrorResponder) -> Result<(), ApiErrorResponder> {
+        __ERROR_RESPONDER.set(f)
+    }
+
+    /// The default [`ApiErrorResponder`].
+    ///
+    /// Returns a [`Response`] whose status is [`ApiError::status_code`] and
+    /// whose JSON body is:
+    ///
+    /// ```json
+    /// { "message": "<ApiError::message()>" }
+    /// ```
+    pub fn default_error_responder(api_error: &dyn ApiError) -> Response {
+        ApiErrorResponse::new(api_error).into_response()
+    }
 
     pub struct ApiErrorResponse<'a> {
         message: Cow<'a, str>,

--- a/api-error/tests/derive.rs
+++ b/api-error/tests/derive.rs
@@ -1,6 +1,8 @@
 // Copyright 2025-Present Centreon
 // SPDX-License-Identifier: Apache-2.0
 
+#![cfg(feature = "axum")]
+
 use api_error::ApiError;
 use axum_core::response::IntoResponse;
 use http::StatusCode;

--- a/api-error/tests/responder.rs
+++ b/api-error/tests/responder.rs
@@ -1,0 +1,43 @@
+// Copyright 2025-Present Centreon
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg(feature = "axum")]
+
+use api_error::{
+    ApiError,
+    axum::{ApiErrorResponse, set_error_responder},
+};
+use axum_core::response::{IntoResponse, Response};
+
+#[derive(Debug, thiserror::Error, ApiError)]
+#[error("boom")]
+#[api_error(status_code = 418, message = "I'm a teapot")]
+struct TeapotError;
+
+fn custom_responder(err: &dyn ApiError) -> Response {
+    let mut resp = ApiErrorResponse::new(err).into_response();
+    resp.headers_mut()
+        .insert("x-custom-responder", "1".parse().unwrap());
+    resp
+}
+
+#[test]
+fn custom_responder_is_used_by_derive() {
+    set_error_responder(custom_responder);
+
+    let resp = TeapotError.into_response();
+    assert_eq!(resp.status(), 418);
+    assert_eq!(resp.headers().get("x-custom-responder").unwrap(), "1");
+}
+
+#[test]
+fn default_responder_serializes_message_as_json() {
+    let body = serde_json::to_string(&ApiErrorResponse::new(&TeapotError)).unwrap();
+    assert_eq!(body, r#"{"message":"I'm a teapot"}"#);
+}
+
+#[test]
+fn default_responder_forwards_status_code() {
+    let resp = TeapotError.into_response();
+    assert_eq!(resp.status(), 418);
+}


### PR DESCRIPTION
## Add an _Error Responder_ API.

An error responder allows to globally set a custom function to convert an `ApiError` into an `axum::Response`. This allows for custom user-encoding and custom behavior.